### PR TITLE
Update build.sbt com.my.currency to com.my.nft_example

### DIFF
--- a/examples/DataApi-NFT/template/build.sbt
+++ b/examples/DataApi-NFT/template/build.sbt
@@ -1,7 +1,7 @@
 import Dependencies._
 import sbt._
 
-ThisBuild / organization := "com.my.currency"
+ThisBuild / organization := "com.my.nft_example"
 ThisBuild / scalaVersion := "2.13.10"
 ThisBuild / evictionErrorLevel := Level.Warn
 


### PR DESCRIPTION
I think this is supposed to be changed to reflect the folders within all of the module subfolders.  Which is nft_example and not currency?