### PR TITLE
Updated NFT UI ml0 endpoint and name to match Euclid output

### DIFF
--- a/examples/nft/sample-ui/.env
+++ b/examples/nft/sample-ui/.env
@@ -1,4 +1,4 @@
 PORT=6542
-REACT_APP_BASE_API_URL=http://localhost:9500
+REACT_APP_METAGRAPH_L0_URL=http://localhost:9200
 GLOBAL_L0_URL=http://localhost:9000
 METAGRAPH_L1_DATA_URL=http://localhost:9400

--- a/examples/nft/sample-ui/src/lib/runtime/environment_context.ts
+++ b/examples/nft/sample-ui/src/lib/runtime/environment_context.ts
@@ -29,8 +29,8 @@ const EnvironmentContext = makeEnvironmentContext({
   nodeEnv: () => getEnvOrError<string>('NODE_ENV'),
   baseApiUrl: () =>
     getEnvOrError<string>(
-      'BASE_API_URL',
-      ...expandByCommonClientPrefixes('BASE_API_URL')
+      'METAGRAPH_L0_URL',
+      ...expandByCommonClientPrefixes('METAGRAPH_L0_URL')
     ),
   globalL0Url: () => getEnvOrError<string>('GLOBAL_L0_URL'),
   metagraphL1DataUrl: () => getEnvOrError<string>('METAGRAPH_L1_DATA_URL')


### PR DESCRIPTION
- Changes BASE_API_URL to METAGRAPH_L0_URL to make it easier to understand/match existing pattern
- Updates url to match latest Euclid output