### PR TITLE
 github-token is no longer required

### DIFF
--- a/examples/custom-transaction-validation/build.sbt
+++ b/examples/custom-transaction-validation/build.sbt
@@ -29,7 +29,6 @@ lazy val currencyL1 = (project in file("modules/l1"))
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
     buildInfoPackage := "com.my.custom_validator.l1",
     resolvers += Resolver.mavenLocal,
-    resolvers += Resolver.githubPackages("abankowski", "http-request-signer"),
     Defaults.itSettings,
     libraryDependencies ++= Seq(
       CompilerPlugin.kindProjector,
@@ -49,7 +48,6 @@ lazy val currencyL0 = (project in file("modules/l0"))
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
     buildInfoPackage := "com.my.custom_validator.l0",
     resolvers += Resolver.mavenLocal,
-    resolvers += Resolver.githubPackages("abankowski", "http-request-signer"),
     Defaults.itSettings,
     libraryDependencies ++= Seq(
       CompilerPlugin.kindProjector,

--- a/examples/nft/build.sbt
+++ b/examples/nft/build.sbt
@@ -29,7 +29,6 @@ lazy val sharedData = (project in file("modules/shared_data"))
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
     buildInfoPackage := "com.my.nft.shared_data",
     resolvers += Resolver.mavenLocal,
-    resolvers += Resolver.githubPackages("abankowski", "http-request-signer"),
     Defaults.itSettings,
     libraryDependencies ++= Seq(
       CompilerPlugin.kindProjector,
@@ -48,7 +47,6 @@ lazy val currencyL1 = (project in file("modules/l1"))
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
     buildInfoPackage := "com.my.nft.l1",
     resolvers += Resolver.mavenLocal,
-    resolvers += Resolver.githubPackages("abankowski", "http-request-signer"),
     Defaults.itSettings,
     libraryDependencies ++= Seq(
       CompilerPlugin.kindProjector,
@@ -69,7 +67,6 @@ lazy val currencyL0 = (project in file("modules/l0"))
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
     buildInfoPackage := "com.my.nft.l0",
     resolvers += Resolver.mavenLocal,
-    resolvers += Resolver.githubPackages("abankowski", "http-request-signer"),
     Defaults.itSettings,
     libraryDependencies ++= Seq(
       CompilerPlugin.kindProjector,
@@ -93,7 +90,6 @@ lazy val dataL1 = (project in file("modules/data_l1"))
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
     buildInfoPackage := "com.my.nft.data_l1",
     resolvers += Resolver.mavenLocal,
-    resolvers += Resolver.githubPackages("abankowski", "http-request-signer"),
     Defaults.itSettings,
     libraryDependencies ++= Seq(
       CompilerPlugin.kindProjector,

--- a/examples/reward-api/build.sbt
+++ b/examples/reward-api/build.sbt
@@ -29,7 +29,6 @@ lazy val currencyL1 = (project in file("modules/l1"))
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
     buildInfoPackage := "com.my.reward_api.l1",
     resolvers += Resolver.mavenLocal,
-    resolvers += Resolver.githubPackages("abankowski", "http-request-signer"),
     Defaults.itSettings,
     libraryDependencies ++= Seq(
       CompilerPlugin.kindProjector,
@@ -49,7 +48,6 @@ lazy val currencyL0 = (project in file("modules/l0"))
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
     buildInfoPackage := "com.my.reward_api.l0",
     resolvers += Resolver.mavenLocal,
-    resolvers += Resolver.githubPackages("abankowski", "http-request-signer"),
     Defaults.itSettings,
     libraryDependencies ++= Seq(
       CompilerPlugin.kindProjector,

--- a/examples/social/build.sbt
+++ b/examples/social/build.sbt
@@ -29,7 +29,6 @@ lazy val sharedData = (project in file("modules/shared_data"))
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
     buildInfoPackage := "com.my.metagraph_social.shared_data",
     resolvers += Resolver.mavenLocal,
-
     Defaults.itSettings,
     libraryDependencies ++= Seq(
       CompilerPlugin.kindProjector,

--- a/examples/social/build.sbt
+++ b/examples/social/build.sbt
@@ -29,7 +29,7 @@ lazy val sharedData = (project in file("modules/shared_data"))
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
     buildInfoPackage := "com.my.metagraph_social.shared_data",
     resolvers += Resolver.mavenLocal,
-    resolvers += Resolver.githubPackages("abankowski", "http-request-signer"),
+
     Defaults.itSettings,
     libraryDependencies ++= Seq(
       CompilerPlugin.kindProjector,
@@ -52,7 +52,6 @@ lazy val currencyL1 = (project in file("modules/l1"))
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
     buildInfoPackage := "com.my.metagraph_social.l1",
     resolvers += Resolver.mavenLocal,
-    resolvers += Resolver.githubPackages("abankowski", "http-request-signer"),
     Defaults.itSettings,
     libraryDependencies ++= Seq(
       CompilerPlugin.kindProjector,
@@ -73,7 +72,6 @@ lazy val currencyL0 = (project in file("modules/l0"))
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
     buildInfoPackage := "com.my.metagraph_social.l0",
     resolvers += Resolver.mavenLocal,
-    resolvers += Resolver.githubPackages("abankowski", "http-request-signer"),
     Defaults.itSettings,
     libraryDependencies ++= Seq(
       CompilerPlugin.kindProjector,
@@ -103,7 +101,6 @@ lazy val dataL1 = (project in file("modules/data_l1"))
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
     buildInfoPackage := "com.my.metagraph_social.data_l1",
     resolvers += Resolver.mavenLocal,
-    resolvers += Resolver.githubPackages("abankowski", "http-request-signer"),
     Defaults.itSettings,
     libraryDependencies ++= Seq(
       CompilerPlugin.kindProjector,

--- a/examples/todo/build.sbt
+++ b/examples/todo/build.sbt
@@ -20,7 +20,6 @@ ThisBuild / assemblyMergeStrategy := {
 lazy val commonSettings = Seq(
   scalacOptions ++= List("-Ymacro-annotations", "-Yrangepos", "-Wconf:cat=unused:info", "-language:reflectiveCalls"),
   resolvers += Resolver.mavenLocal,
-  resolvers += Resolver.githubPackages("abankowski", "http-request-signer"),
 ) ++ Defaults.itSettings
 
 lazy val commonLibraryDependencies: Seq[ModuleID] = Seq(

--- a/examples/voting-poll/build.sbt
+++ b/examples/voting-poll/build.sbt
@@ -29,7 +29,6 @@ lazy val sharedData = (project in file("modules/shared_data"))
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
     buildInfoPackage := "com.my.voting_poll.shared_data",
     resolvers += Resolver.mavenLocal,
-    resolvers += Resolver.githubPackages("abankowski", "http-request-signer"),
     Defaults.itSettings,
     libraryDependencies ++= Seq(
       CompilerPlugin.kindProjector,
@@ -48,7 +47,6 @@ lazy val currencyL1 = (project in file("modules/l1"))
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
     buildInfoPackage := "com.my.voting_poll.l1",
     resolvers += Resolver.mavenLocal,
-    resolvers += Resolver.githubPackages("abankowski", "http-request-signer"),
     Defaults.itSettings,
     libraryDependencies ++= Seq(
       CompilerPlugin.kindProjector,
@@ -69,7 +67,6 @@ lazy val currencyL0 = (project in file("modules/l0"))
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
     buildInfoPackage := "com.my.voting_poll.l0",
     resolvers += Resolver.mavenLocal,
-    resolvers += Resolver.githubPackages("abankowski", "http-request-signer"),
     Defaults.itSettings,
     libraryDependencies ++= Seq(
       CompilerPlugin.kindProjector,
@@ -99,7 +96,6 @@ lazy val dataL1 = (project in file("modules/data_l1"))
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
     buildInfoPackage := "com.my.voting_poll.data_l1",
     resolvers += Resolver.mavenLocal,
-    resolvers += Resolver.githubPackages("abankowski", "http-request-signer"),
     Defaults.itSettings,
     libraryDependencies ++= Seq(
       CompilerPlugin.kindProjector,

--- a/examples/water-and-energy-usage/build.sbt
+++ b/examples/water-and-energy-usage/build.sbt
@@ -29,7 +29,6 @@ lazy val sharedData = (project in file("modules/shared_data"))
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
     buildInfoPackage := "com.my.water_and_energy_usage.shared_data",
     resolvers += Resolver.mavenLocal,
-    resolvers += Resolver.githubPackages("abankowski", "http-request-signer"),
     Defaults.itSettings,
     libraryDependencies ++= Seq(
       CompilerPlugin.kindProjector,
@@ -49,7 +48,6 @@ lazy val currencyL1 = (project in file("modules/l1"))
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
     buildInfoPackage := "com.my.water_and_energy_usage.l1",
     resolvers += Resolver.mavenLocal,
-    resolvers += Resolver.githubPackages("abankowski", "http-request-signer"),
     Defaults.itSettings,
     libraryDependencies ++= Seq(
       CompilerPlugin.kindProjector,
@@ -70,7 +68,6 @@ lazy val currencyL0 = (project in file("modules/l0"))
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
     buildInfoPackage := "com.my.water_and_energy_usage.l0",
     resolvers += Resolver.mavenLocal,
-    resolvers += Resolver.githubPackages("abankowski", "http-request-signer"),
     Defaults.itSettings,
     libraryDependencies ++= Seq(
       CompilerPlugin.kindProjector,
@@ -94,7 +91,6 @@ lazy val dataL1 = (project in file("modules/data_l1"))
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
     buildInfoPackage := "com.my.water_and_energy_usage.data_l1",
     resolvers += Resolver.mavenLocal,
-    resolvers += Resolver.githubPackages("abankowski", "http-request-signer"),
     Defaults.itSettings,
     libraryDependencies ++= Seq(
       CompilerPlugin.kindProjector,


### PR DESCRIPTION
 removed the following line from all the example's build.sbt

 resolvers += Resolver.githubPackages("abankowski", "http-request-signer"),