### PR TITLE
update `todo` example

### DIFF
--- a/examples/todo/build.sbt
+++ b/examples/todo/build.sbt
@@ -20,14 +20,13 @@ ThisBuild / assemblyMergeStrategy := {
 lazy val commonSettings = Seq(
   scalacOptions ++= List("-Ymacro-annotations", "-Yrangepos", "-Wconf:cat=unused:info", "-language:reflectiveCalls"),
   resolvers += Resolver.mavenLocal,
-  resolvers += Resolver.githubPackages("abankowski", "http-request-signer"),
 ) ++ Defaults.itSettings
 
 lazy val commonLibraryDependencies: Seq[ModuleID] = Seq(
   CompilerPlugin.kindProjector,
   CompilerPlugin.betterMonadicFor,
   CompilerPlugin.semanticDB,
-  Libraries.tessellationNodeShared,
+  Libraries.tessellationSdk,
   Libraries.cats,
   Libraries.catsEffect,
   Libraries.pureconfigCore,
@@ -77,7 +76,7 @@ lazy val currencyL0 = (project in file("modules/l0"))
     commonSettings,
     commonTestSettings,
     name := "todo-currency-l0",
-    libraryDependencies ++= (commonLibraryDependencies ++ Seq(Libraries.tessellationCurrencyL0))
+    libraryDependencies ++= (commonLibraryDependencies ++ Seq(Libraries.tessellationSdk))
   )
 
 lazy val currencyL1 = (project in file("modules/l1"))
@@ -88,7 +87,7 @@ lazy val currencyL1 = (project in file("modules/l1"))
     commonSettings,
     commonTestSettings,
     name := "todo-currency-l1",
-    libraryDependencies ++= (commonLibraryDependencies ++ Seq(Libraries.tessellationCurrencyL1))
+    libraryDependencies ++= (commonLibraryDependencies ++ Seq(Libraries.tessellationSdk))
   )
 
 lazy val dataL1 = (project in file("modules/data_l1"))
@@ -99,5 +98,5 @@ lazy val dataL1 = (project in file("modules/data_l1"))
     commonSettings,
     commonTestSettings,
     name := "todo-data-l1",
-    libraryDependencies ++= (commonLibraryDependencies ++ Seq(Libraries.tessellationCurrencyL1))
+    libraryDependencies ++= (commonLibraryDependencies ++ Seq(Libraries.tessellationSdk))
   )

--- a/examples/todo/modules/data_l1/src/main/scala/com/my/data_l1/DataL1CustomRoutes.scala
+++ b/examples/todo/modules/data_l1/src/main/scala/com/my/data_l1/DataL1CustomRoutes.scala
@@ -4,8 +4,8 @@ import cats.effect.{Async, Clock}
 import cats.implicits.{toFlatMapOps, toFunctorOps}
 import cats.syntax.either._
 
-import org.tessellation.currency.dataApplication.{DataApplicationValidationError, L1NodeContext}
-import org.tessellation.json.JsonSerializer
+import io.constellationnetwork.currency.dataApplication.{DataApplicationValidationError, L1NodeContext}
+import io.constellationnetwork.json.JsonSerializer
 
 import com.my.data_l1.DataL1NodeContext.syntax._
 import com.my.shared_data.lib.MetagraphPublicRoutes

--- a/examples/todo/modules/data_l1/src/main/scala/com/my/data_l1/DataL1NodeContext.scala
+++ b/examples/todo/modules/data_l1/src/main/scala/com/my/data_l1/DataL1NodeContext.scala
@@ -4,11 +4,11 @@ import cats.Monad
 import cats.data.EitherT
 import cats.implicits.{toBifunctorOps, toFunctorOps, toTraverseOps}
 
-import org.tessellation.currency.dataApplication.{DataApplicationValidationError, L1NodeContext}
-import org.tessellation.currency.schema.currency.CurrencyIncrementalSnapshot
-import org.tessellation.json.JsonSerializer
-import org.tessellation.schema.GlobalIncrementalSnapshot
-import org.tessellation.security.Hashed
+import io.constellationnetwork.currency.dataApplication.{DataApplicationValidationError, L1NodeContext}
+import io.constellationnetwork.currency.schema.currency.CurrencyIncrementalSnapshot
+import io.constellationnetwork.json.JsonSerializer
+import io.constellationnetwork.schema.GlobalIncrementalSnapshot
+import io.constellationnetwork.security.Hashed
 
 import com.my.shared_data.lib.JsonBinaryCodec
 import com.my.shared_data.schema.OnChain

--- a/examples/todo/modules/data_l1/src/main/scala/com/my/data_l1/DataL1Service.scala
+++ b/examples/todo/modules/data_l1/src/main/scala/com/my/data_l1/DataL1Service.scala
@@ -1,20 +1,17 @@
 package com.my.data_l1
 
-import cats.data.NonEmptyList
 import cats.effect.Async
 import cats.syntax.all._
 
-import org.tessellation.currency.dataApplication._
-import org.tessellation.currency.dataApplication.dataApplication.{
+import io.constellationnetwork.currency.dataApplication._
+import io.constellationnetwork.currency.dataApplication.dataApplication.{
   DataApplicationBlock,
   DataApplicationValidationErrorOr
 }
-import org.tessellation.json.JsonSerializer
-import org.tessellation.schema.SnapshotOrdinal
-import org.tessellation.security.Hasher
-import org.tessellation.security.hash.Hash
-import org.tessellation.security.signature.Signed
-import org.tessellation.security.signature.Signed._
+import io.constellationnetwork.json.JsonSerializer
+import io.constellationnetwork.security.Hasher
+import io.constellationnetwork.security.signature.Signed
+import io.constellationnetwork.security.signature.Signed._
 
 import com.my.data_l1.DataL1NodeContext.syntax.DataL1NodeContextOps
 import com.my.shared_data.lib.CirceOps.implicits._
@@ -73,24 +70,6 @@ object DataL1Service {
 
         override val signedDataEntityDecoder: EntityDecoder[F, Signed[TodoUpdate]] = circeEntityDecoder
 
-        override def getCalculatedState(implicit
-          context: L1NodeContext[F]
-        ): F[(SnapshotOrdinal, CalculatedState)] =
-          (SnapshotOrdinal.MinValue, CalculatedState.genesis).pure[F]
-
-        override def setCalculatedState(ordinal: SnapshotOrdinal, state: CalculatedState)(implicit
-          context: L1NodeContext[F]
-        ): F[Boolean] = true.pure[F]
-
-        override def hashCalculatedState(state: CalculatedState)(implicit context: L1NodeContext[F]): F[Hash] =
-          Hash.empty.pure[F]
-
-        override def validateData(
-          state:   DataState[OnChain, CalculatedState],
-          updates: NonEmptyList[Signed[TodoUpdate]]
-        )(implicit context: L1NodeContext[F]): F[DataApplicationValidationErrorOr[Unit]] =
-          ().validNec[DataApplicationValidationError].pure[F]
-
         override def validateUpdate(
           update: TodoUpdate
         )(implicit context: L1NodeContext[F]): F[DataApplicationValidationErrorOr[Unit]] =
@@ -100,11 +79,6 @@ object DataL1Service {
               onchain => validator.verify(onchain, update)
             )
           }
-
-        override def combine(
-          state:   DataState[OnChain, CalculatedState],
-          updates: List[Signed[TodoUpdate]]
-        )(implicit context: L1NodeContext[F]): F[DataState[OnChain, CalculatedState]] = state.pure[F]
 
         override def routes(implicit context: L1NodeContext[F]): HttpRoutes[F] =
           new DataL1CustomRoutes[F].public

--- a/examples/todo/modules/data_l1/src/main/scala/com/my/data_l1/DataL1Validator.scala
+++ b/examples/todo/modules/data_l1/src/main/scala/com/my/data_l1/DataL1Validator.scala
@@ -5,9 +5,9 @@ import cats.implicits.{toFlatMapOps, toFoldableOps, toFunctorOps}
 import cats.syntax.applicative._
 import cats.syntax.validated._
 
-import org.tessellation.currency.dataApplication.DataApplicationValidationError
-import org.tessellation.currency.dataApplication.dataApplication.DataApplicationValidationErrorOr
-import org.tessellation.security.Hasher
+import io.constellationnetwork.currency.dataApplication.DataApplicationValidationError
+import io.constellationnetwork.currency.dataApplication.dataApplication.DataApplicationValidationErrorOr
+import io.constellationnetwork.security.Hasher
 
 import com.my.shared_data.lib.UpdateValidator
 import com.my.shared_data.lifecycle.ValidatorRules

--- a/examples/todo/modules/data_l1/src/main/scala/com/my/data_l1/Main.scala
+++ b/examples/todo/modules/data_l1/src/main/scala/com/my/data_l1/Main.scala
@@ -5,13 +5,13 @@ import java.util.UUID
 import cats.effect.{IO, Resource}
 import cats.syntax.all._
 
-import org.tessellation.currency.dataApplication._
-import org.tessellation.currency.l1.CurrencyL1App
-import org.tessellation.ext.cats.effect.ResourceIO
-import org.tessellation.json.JsonSerializer
-import org.tessellation.schema.cluster.ClusterId
-import org.tessellation.schema.semver.{MetagraphVersion, TessellationVersion}
-import org.tessellation.security.Hasher
+import io.constellationnetwork.currency.dataApplication._
+import io.constellationnetwork.currency.l1.CurrencyL1App
+import io.constellationnetwork.ext.cats.effect.ResourceIO
+import io.constellationnetwork.json.JsonSerializer
+import io.constellationnetwork.schema.cluster.ClusterId
+import io.constellationnetwork.schema.semver.{MetagraphVersion, TessellationVersion}
+import io.constellationnetwork.security.Hasher
 
 import com.my.buildinfo.BuildInfo
 import com.my.shared_data.app.ApplicationConfigOps
@@ -25,7 +25,7 @@ object Main
       name = "data-app-l1",
       header = "Metagraph Data L1 node",
       clusterId = ClusterId(UUID.fromString("517c3a05-9219-471b-a54c-21b7d72f4ae5")),
-      tessellationVersion = TessellationVersion.unsafeFrom(org.tessellation.BuildInfo.version),
+      tessellationVersion = TessellationVersion.unsafeFrom(io.constellationnetwork.BuildInfo.version),
       metagraphVersion = MetagraphVersion.unsafeFrom(BuildInfo.version)
     ) {
 

--- a/examples/todo/modules/l0/src/main/scala/com/my/metagraph_l0/ML0CustomRoutes.scala
+++ b/examples/todo/modules/l0/src/main/scala/com/my/metagraph_l0/ML0CustomRoutes.scala
@@ -3,9 +3,9 @@ package com.my.metagraph_l0
 import cats.effect.Async
 import cats.syntax.all._
 
-import org.tessellation.currency.dataApplication.{DataApplicationValidationError, L0NodeContext}
-import org.tessellation.json.JsonSerializer
-import org.tessellation.node.shared.ext.http4s.SnapshotOrdinalVar
+import io.constellationnetwork.currency.dataApplication.{DataApplicationValidationError, L0NodeContext}
+import io.constellationnetwork.json.JsonSerializer
+import io.constellationnetwork.node.shared.ext.http4s.SnapshotOrdinalVar
 
 import com.my.metagraph_l0.ML0NodeContext.syntax._
 import com.my.shared_data.lib.{CheckpointService, MetagraphPublicRoutes}

--- a/examples/todo/modules/l0/src/main/scala/com/my/metagraph_l0/ML0NodeContext.scala
+++ b/examples/todo/modules/l0/src/main/scala/com/my/metagraph_l0/ML0NodeContext.scala
@@ -7,13 +7,13 @@ import cats.syntax.all._
 
 import scala.collection.immutable.SortedSet
 
-import org.tessellation.currency.dataApplication.dataApplication.DataApplicationValidationErrorOr
-import org.tessellation.currency.dataApplication.{DataApplicationValidationError, DataState, L0NodeContext}
-import org.tessellation.currency.schema.currency.CurrencyIncrementalSnapshot
-import org.tessellation.json.JsonSerializer
-import org.tessellation.schema.SnapshotOrdinal
-import org.tessellation.security.signature.Signed
-import org.tessellation.security.{Hashed, SecurityProvider}
+import io.constellationnetwork.currency.dataApplication.dataApplication.DataApplicationValidationErrorOr
+import io.constellationnetwork.currency.dataApplication.{DataApplicationValidationError, DataState, L0NodeContext}
+import io.constellationnetwork.currency.schema.currency.CurrencyIncrementalSnapshot
+import io.constellationnetwork.json.JsonSerializer
+import io.constellationnetwork.schema.SnapshotOrdinal
+import io.constellationnetwork.security.signature.Signed
+import io.constellationnetwork.security.{Hashed, SecurityProvider}
 
 import com.my.shared_data.lib.syntax.CurrencyIncrementalSnapshotOps
 import com.my.shared_data.lib.{JsonBinaryCodec, LatestUpdateValidator, SignedUpdateReducer}

--- a/examples/todo/modules/l0/src/main/scala/com/my/metagraph_l0/ML0Service.scala
+++ b/examples/todo/modules/l0/src/main/scala/com/my/metagraph_l0/ML0Service.scala
@@ -5,17 +5,17 @@ import cats.data.NonEmptyList
 import cats.effect.Async
 import cats.syntax.all._
 
-import org.tessellation.currency.dataApplication._
-import org.tessellation.currency.dataApplication.dataApplication.{
+import io.constellationnetwork.currency.dataApplication._
+import io.constellationnetwork.currency.dataApplication.dataApplication.{
   DataApplicationBlock,
   DataApplicationValidationErrorOr
 }
-import org.tessellation.currency.schema.currency.CurrencyIncrementalSnapshot
-import org.tessellation.json.JsonSerializer
-import org.tessellation.schema.SnapshotOrdinal
-import org.tessellation.security.hash.Hash
-import org.tessellation.security.signature.Signed
-import org.tessellation.security.{Hashed, Hasher, SecurityProvider}
+import io.constellationnetwork.currency.schema.currency.CurrencyIncrementalSnapshot
+import io.constellationnetwork.json.JsonSerializer
+import io.constellationnetwork.schema.SnapshotOrdinal
+import io.constellationnetwork.security.hash.Hash
+import io.constellationnetwork.security.signature.Signed
+import io.constellationnetwork.security.{Hashed, Hasher, SecurityProvider}
 
 import com.my.metagraph_l0.ML0NodeContext.syntax.dataStateOps
 import com.my.shared_data.lib.CirceOps.implicits._
@@ -114,10 +114,6 @@ object ML0Service {
           updates: NonEmptyList[Signed[TodoUpdate]]
         )(implicit context: L0NodeContext[F]): F[DataApplicationValidationErrorOr[Unit]] =
           state.verify(updates)(validator)
-
-        override def validateUpdate(update: TodoUpdate)(implicit
-          context: L0NodeContext[F]
-        ): F[DataApplicationValidationErrorOr[Unit]] = ().validNec.pure[F]
 
         override def combine(
           state:   DataState[OnChain, CalculatedState],

--- a/examples/todo/modules/l0/src/main/scala/com/my/metagraph_l0/ML0Validator.scala
+++ b/examples/todo/modules/l0/src/main/scala/com/my/metagraph_l0/ML0Validator.scala
@@ -5,10 +5,10 @@ import cats.implicits.{toFlatMapOps, toFoldableOps, toFunctorOps}
 import cats.syntax.applicative._
 import cats.syntax.validated._
 
-import org.tessellation.currency.dataApplication.dataApplication.DataApplicationValidationErrorOr
-import org.tessellation.currency.dataApplication.{DataApplicationValidationError, DataState}
-import org.tessellation.security.Hasher
-import org.tessellation.security.signature.Signed
+import io.constellationnetwork.currency.dataApplication.dataApplication.DataApplicationValidationErrorOr
+import io.constellationnetwork.currency.dataApplication.{DataApplicationValidationError, DataState}
+import io.constellationnetwork.security.Hasher
+import io.constellationnetwork.security.signature.Signed
 
 import com.my.shared_data.lib.UpdateValidator
 import com.my.shared_data.lifecycle.ValidatorRules

--- a/examples/todo/modules/l0/src/main/scala/com/my/metagraph_l0/Main.scala
+++ b/examples/todo/modules/l0/src/main/scala/com/my/metagraph_l0/Main.scala
@@ -6,16 +6,15 @@ import cats.effect.std.Supervisor
 import cats.effect.{IO, Resource}
 import cats.implicits._
 
-import scala.concurrent.duration.DurationInt
 
-import org.tessellation.currency.dataApplication._
-import org.tessellation.currency.l0.CurrencyL0App
-import org.tessellation.ext.cats.effect.ResourceIO
-import org.tessellation.json.JsonSerializer
-import org.tessellation.node.shared.domain.Daemon
-import org.tessellation.schema.cluster.ClusterId
-import org.tessellation.schema.semver.{MetagraphVersion, TessellationVersion}
-import org.tessellation.security.{Hasher, SecurityProvider}
+import io.constellationnetwork.currency.dataApplication._
+import io.constellationnetwork.currency.l0.CurrencyL0App
+import io.constellationnetwork.ext.cats.effect.ResourceIO
+import io.constellationnetwork.json.JsonSerializer
+import io.constellationnetwork.node.shared.domain.Daemon
+import io.constellationnetwork.schema.cluster.ClusterId
+import io.constellationnetwork.schema.semver.{MetagraphVersion, TessellationVersion}
+import io.constellationnetwork.security.{Hasher, SecurityProvider}
 
 import com.my.buildinfo.BuildInfo
 import com.my.shared_data.app.{ApplicationConfig, ApplicationConfigOps}
@@ -29,7 +28,7 @@ object Main
       name = "metagraph-l0",
       header = "Metagraph L0 node",
       clusterId = ClusterId(UUID.fromString("517c3a05-9219-471b-a54c-21b7d72f4ae5")),
-      tessellationVersion = TessellationVersion.unsafeFrom(org.tessellation.BuildInfo.version),
+      tessellationVersion = TessellationVersion.unsafeFrom(io.constellationnetwork.BuildInfo.version),
       metagraphVersion = MetagraphVersion.unsafeFrom(BuildInfo.version)
     ) {
 

--- a/examples/todo/modules/l1/src/main/scala/com/my/currency_l1/Main.scala
+++ b/examples/todo/modules/l1/src/main/scala/com/my/currency_l1/Main.scala
@@ -2,9 +2,9 @@ package com.my.currency_l1
 
 import java.util.UUID
 
-import org.tessellation.currency.l1.CurrencyL1App
-import org.tessellation.schema.cluster.ClusterId
-import org.tessellation.schema.semver.{MetagraphVersion, TessellationVersion}
+import io.constellationnetwork.currency.l1.CurrencyL1App
+import io.constellationnetwork.schema.cluster.ClusterId
+import io.constellationnetwork.schema.semver.{MetagraphVersion, TessellationVersion}
 
 import com.my.buildinfo.BuildInfo
 
@@ -13,6 +13,6 @@ object Main
       name = "currency-l1",
       header = "currency L1 node",
       clusterId = ClusterId(UUID.fromString("517c3a05-9219-471b-a54c-21b7d72f4ae5")),
-      tessellationVersion = TessellationVersion.unsafeFrom(org.tessellation.BuildInfo.version),
+      tessellationVersion = TessellationVersion.unsafeFrom(io.constellationnetwork.BuildInfo.version),
       metagraphVersion = MetagraphVersion.unsafeFrom(BuildInfo.version)
     ) {}

--- a/examples/todo/modules/shared-data/src/main/resources/logback.xml
+++ b/examples/todo/modules/shared-data/src/main/resources/logback.xml
@@ -9,7 +9,7 @@
         <appender-ref ref="STDOUT" />
     </root>
 
-    <logger name="org.tessellation" level="DEBUG" />
+    <logger name="io.constellationnetwork" level="DEBUG" />
     <logger name="org.http4s.server.middleware.RequestLogger" level="OFF" />
     <logger name="org.http4s.server.middleware.ResponseLogger" level="OFF" />
     <logger name="org.http4s.client.middleware.RequestLogger" level="OFF" />

--- a/examples/todo/modules/shared-data/src/main/scala/com/my/shared_data/lib/Checkpoint.scala
+++ b/examples/todo/modules/shared-data/src/main/scala/com/my/shared_data/lib/Checkpoint.scala
@@ -1,6 +1,6 @@
 package com.my.shared_data.lib
 
-import org.tessellation.schema.SnapshotOrdinal
+import io.constellationnetwork.schema.SnapshotOrdinal
 
 import derevo.circe.magnolia.{decoder, encoder}
 import derevo.derive

--- a/examples/todo/modules/shared-data/src/main/scala/com/my/shared_data/lib/CirceOps.scala
+++ b/examples/todo/modules/shared-data/src/main/scala/com/my/shared_data/lib/CirceOps.scala
@@ -1,6 +1,6 @@
 package com.my.shared_data.lib
 
-import org.tessellation.currency.dataApplication.DataUpdate
+import io.constellationnetwork.currency.dataApplication.DataUpdate
 
 import com.my.shared_data.schema.Updates.TodoUpdate
 

--- a/examples/todo/modules/shared-data/src/main/scala/com/my/shared_data/lib/JsonBinaryCodec.scala
+++ b/examples/todo/modules/shared-data/src/main/scala/com/my/shared_data/lib/JsonBinaryCodec.scala
@@ -3,7 +3,7 @@ package com.my.shared_data.lib
 import cats.effect.Sync
 import cats.implicits.toFunctorOps
 
-import org.tessellation.json.JsonSerializer
+import io.constellationnetwork.json.JsonSerializer
 
 import io.circe.jawn.JawnParser
 import io.circe.syntax.EncoderOps

--- a/examples/todo/modules/shared-data/src/main/scala/com/my/shared_data/lib/LatestUpdateValidator.scala
+++ b/examples/todo/modules/shared-data/src/main/scala/com/my/shared_data/lib/LatestUpdateValidator.scala
@@ -4,7 +4,7 @@ import cats.data.NonEmptyList
 import cats.effect.Async
 import cats.implicits.toFunctorOps
 
-import org.tessellation.currency.dataApplication.dataApplication.DataApplicationValidationErrorOr
+import io.constellationnetwork.currency.dataApplication.dataApplication.DataApplicationValidationErrorOr
 
 import com.my.shared_data.lib.UpdateValidator
 

--- a/examples/todo/modules/shared-data/src/main/scala/com/my/shared_data/lib/MetagraphPublicRoutes.scala
+++ b/examples/todo/modules/shared-data/src/main/scala/com/my/shared_data/lib/MetagraphPublicRoutes.scala
@@ -2,8 +2,8 @@ package com.my.shared_data.lib
 
 import cats.effect.Async
 
-import org.tessellation.currency.dataApplication.DataApplicationValidationError
-import org.tessellation.routes.internal.{InternalUrlPrefix, PublicRoutes}
+import io.constellationnetwork.currency.dataApplication.DataApplicationValidationError
+import io.constellationnetwork.routes.internal.{InternalUrlPrefix, PublicRoutes}
 
 import eu.timepit.refined.auto._
 import io.circe.Encoder

--- a/examples/todo/modules/shared-data/src/main/scala/com/my/shared_data/lib/SignedUpdateReducer.scala
+++ b/examples/todo/modules/shared-data/src/main/scala/com/my/shared_data/lib/SignedUpdateReducer.scala
@@ -5,8 +5,8 @@ import cats.implicits.toFoldableOps
 
 import scala.collection.immutable.SortedSet
 
-import org.tessellation.currency.dataApplication.L0NodeContext
-import org.tessellation.security.signature.Signed
+import io.constellationnetwork.currency.dataApplication.L0NodeContext
+import io.constellationnetwork.security.signature.Signed
 
 import com.my.shared_data.lifecycle.StateUpdateCombiner
 

--- a/examples/todo/modules/shared-data/src/main/scala/com/my/shared_data/lib/UpdateValidator.scala
+++ b/examples/todo/modules/shared-data/src/main/scala/com/my/shared_data/lib/UpdateValidator.scala
@@ -1,6 +1,6 @@
 package com.my.shared_data.lib
 
-import org.tessellation.currency.dataApplication.dataApplication.DataApplicationValidationErrorOr
+import io.constellationnetwork.currency.dataApplication.dataApplication.DataApplicationValidationErrorOr
 
 trait UpdateValidator[F[_], U, T] {
   def verify(state: T, update: U): F[DataApplicationValidationErrorOr[Unit]]

--- a/examples/todo/modules/shared-data/src/main/scala/com/my/shared_data/lifecycle/StateUpdateCombiner.scala
+++ b/examples/todo/modules/shared-data/src/main/scala/com/my/shared_data/lifecycle/StateUpdateCombiner.scala
@@ -3,11 +3,11 @@ package com.my.shared_data.lifecycle
 import cats.effect.Async
 import cats.implicits.{toFlatMapOps, toFunctorOps}
 
-import org.tessellation.currency.dataApplication.{DataState, L0NodeContext}
-import org.tessellation.ext.cats.syntax.next.catsSyntaxNext
-import org.tessellation.schema.SnapshotOrdinal
-import org.tessellation.security.signature.Signed
-import org.tessellation.security.{Hasher, SecurityProvider}
+import io.constellationnetwork.currency.dataApplication.{DataState, L0NodeContext}
+import io.constellationnetwork.ext.cats.syntax.next.catsSyntaxNext
+import io.constellationnetwork.schema.SnapshotOrdinal
+import io.constellationnetwork.security.signature.Signed
+import io.constellationnetwork.security.{Hasher, SecurityProvider}
 
 import com.my.shared_data.schema.TaskRecord.generateId
 import com.my.shared_data.schema.Updates.TodoUpdate

--- a/examples/todo/modules/shared-data/src/main/scala/com/my/shared_data/lifecycle/ValidatorRules.scala
+++ b/examples/todo/modules/shared-data/src/main/scala/com/my/shared_data/lifecycle/ValidatorRules.scala
@@ -7,8 +7,8 @@ import cats.syntax.validated._
 
 import scala.concurrent.duration.DurationInt
 
-import org.tessellation.currency.dataApplication.DataApplicationValidationError
-import org.tessellation.currency.dataApplication.dataApplication.DataApplicationValidationErrorOr
+import io.constellationnetwork.currency.dataApplication.DataApplicationValidationError
+import io.constellationnetwork.currency.dataApplication.dataApplication.DataApplicationValidationErrorOr
 
 import com.my.shared_data.schema.Updates.ModifyTask
 import com.my.shared_data.schema.{OnChain, TaskStatus}

--- a/examples/todo/modules/shared-data/src/main/scala/com/my/shared_data/schema/CalculatedState.scala
+++ b/examples/todo/modules/shared-data/src/main/scala/com/my/shared_data/schema/CalculatedState.scala
@@ -1,6 +1,6 @@
 package com.my.shared_data.schema
 
-import org.tessellation.currency.dataApplication.DataCalculatedState
+import io.constellationnetwork.currency.dataApplication.DataCalculatedState
 
 import derevo.circe.magnolia.{decoder, encoder}
 import derevo.derive

--- a/examples/todo/modules/shared-data/src/main/scala/com/my/shared_data/schema/OnChain.scala
+++ b/examples/todo/modules/shared-data/src/main/scala/com/my/shared_data/schema/OnChain.scala
@@ -1,6 +1,6 @@
 package com.my.shared_data.schema
 
-import org.tessellation.currency.dataApplication.DataOnChainState
+import io.constellationnetwork.currency.dataApplication.DataOnChainState
 
 import derevo.circe.magnolia.{decoder, encoder}
 import derevo.derive

--- a/examples/todo/modules/shared-data/src/main/scala/com/my/shared_data/schema/TaskRecord.scala
+++ b/examples/todo/modules/shared-data/src/main/scala/com/my/shared_data/schema/TaskRecord.scala
@@ -3,9 +3,9 @@ package com.my.shared_data.schema
 import cats.effect.Async
 import cats.implicits.toFunctorOps
 
-import org.tessellation.schema.SnapshotOrdinal
-import org.tessellation.schema.address.Address
-import org.tessellation.security.Hasher
+import io.constellationnetwork.schema.SnapshotOrdinal
+import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.security.Hasher
 
 import com.my.shared_data.schema.Updates.CreateTask
 

--- a/examples/todo/modules/shared-data/src/main/scala/com/my/shared_data/schema/Updates.scala
+++ b/examples/todo/modules/shared-data/src/main/scala/com/my/shared_data/schema/Updates.scala
@@ -1,6 +1,6 @@
 package com.my.shared_data.schema
 
-import org.tessellation.currency.dataApplication.DataUpdate
+import io.constellationnetwork.currency.dataApplication.DataUpdate
 
 import derevo.circe.magnolia.{decoder, encoder}
 import derevo.derive

--- a/examples/todo/project/Dependencies.scala
+++ b/examples/todo/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
 
   object V {
-    val tessellation = "2.8.1"
+    val tessellation = "3.5.0-rc.0"
     val decline = "2.4.1"
     val cats = "2.9.0"
     val catsEffect = "3.4.2"
@@ -11,7 +11,7 @@ object Dependencies {
     val weaver = "0.8.1"
     val pureconfig = "0.17.4"
   }
-  def tessellation(artifact: String): ModuleID = "org.constellation" %% s"tessellation-$artifact" % V.tessellation
+  def tessellation(artifact: String): ModuleID = "io.constellationnetwork" %% s"tessellation-$artifact" % V.tessellation
 
   def decline(artifact: String = ""): ModuleID =
     "com.monovore" %% {
@@ -19,9 +19,7 @@ object Dependencies {
     } % V.decline
 
   object Libraries {
-    val tessellationNodeShared = tessellation("node-shared")
-    val tessellationCurrencyL0 = tessellation("currency-l0")
-    val tessellationCurrencyL1 = tessellation("currency-l1")
+    val tessellationSdk = tessellation("sdk")
     val declineCore = decline()
     val declineEffect = decline("effect")
     val declineRefined = decline("refined")

--- a/examples/todo/project/plugins.sbt
+++ b/examples/todo/project/plugins.sbt
@@ -6,7 +6,6 @@ addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.10.1")
 addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.5.3")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.2.0")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
-addSbtPlugin("com.codecommit" % "sbt-github-packages" % "0.5.3")
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.6.3")
 
 addDependencyTreePlugin


### PR DESCRIPTION
Updating the `todo` metagraph example to use tessellation `3.5.0-rc0` and aligning with euclid `0.17.0`