### PR TITLE
update `custom-validation` example

### DIFF
--- a/examples/custom-transaction-validation/build.sbt
+++ b/examples/custom-transaction-validation/build.sbt
@@ -29,13 +29,12 @@ lazy val currencyL1 = (project in file("modules/l1"))
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
     buildInfoPackage := "com.my.custom_validator.l1",
     resolvers += Resolver.mavenLocal,
-    resolvers += Resolver.githubPackages("abankowski", "http-request-signer"),
     Defaults.itSettings,
     libraryDependencies ++= Seq(
       CompilerPlugin.kindProjector,
       CompilerPlugin.betterMonadicFor,
       CompilerPlugin.semanticDB,
-      Libraries.tessellationCurrencyL1
+      Libraries.tessellationSdk
     )
   )
 
@@ -49,7 +48,6 @@ lazy val currencyL0 = (project in file("modules/l0"))
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
     buildInfoPackage := "com.my.custom_validator.l0",
     resolvers += Resolver.mavenLocal,
-    resolvers += Resolver.githubPackages("abankowski", "http-request-signer"),
     Defaults.itSettings,
     libraryDependencies ++= Seq(
       CompilerPlugin.kindProjector,
@@ -58,7 +56,7 @@ lazy val currencyL0 = (project in file("modules/l0"))
       Libraries.declineRefined,
       Libraries.declineCore,
       Libraries.declineEffect,
-      Libraries.tessellationCurrencyL0,
+      Libraries.tessellationSdk,
       Libraries.requests
     )
   )

--- a/examples/custom-transaction-validation/modules/l0/src/main/scala/com/my/custom_validator/l0/Main.scala
+++ b/examples/custom-transaction-validation/modules/l0/src/main/scala/com/my/custom_validator/l0/Main.scala
@@ -1,10 +1,11 @@
 package com.my.custom_validator.l0
 
 import java.util.UUID
-import org.tessellation.BuildInfo
-import org.tessellation.schema.cluster.ClusterId
-import org.tessellation.schema.semver.MetagraphVersion
-import org.tessellation.schema.semver.TessellationVersion
+
+import io.constellationnetwork.BuildInfo
+import io.constellationnetwork.currency.l0.CurrencyL0App
+import io.constellationnetwork.schema.cluster.ClusterId
+import io.constellationnetwork.schema.semver.{MetagraphVersion, TessellationVersion}
 
 object Main
   extends CurrencyL0App(
@@ -12,6 +13,6 @@ object Main
     "custom-transaction-validation L0 node",
     ClusterId(UUID.fromString("517c3a05-9219-471b-a54c-21b7d72f4ae5")),
     tessellationVersion = TessellationVersion.unsafeFrom(BuildInfo.version),
-    metagraphVersion = MetagraphVersion.unsafeFrom(BuildInfo.version),
+    metagraphVersion = MetagraphVersion.unsafeFrom(BuildInfo.version)
   ) {
 }

--- a/examples/custom-transaction-validation/modules/l1/src/main/scala/com/my/custom_validator/l1/Main.scala
+++ b/examples/custom-transaction-validation/modules/l1/src/main/scala/com/my/custom_validator/l1/Main.scala
@@ -1,17 +1,16 @@
 package com.my.custom_validator.l1
 
 import java.util.UUID
-import org.tessellation.BuildInfo
-import org.tessellation.currency.l1.CurrencyL1App
-import org.tessellation.schema.cluster.ClusterId
-import org.tessellation.schema.transaction.Transaction
-import org.tessellation.schema.semver.MetagraphVersion
-import org.tessellation.schema.semver.TessellationVersion
-import org.tessellation.security.Hashed
-import org.tessellation.dag.l1.domain.transaction.CustomContextualTransactionValidator
-import org.tessellation.dag.l1.domain.transaction.ContextualTransactionValidator.CustomValidationError
-import org.tessellation.dag.l1.domain.transaction.TransactionValidatorContext
+
 import eu.timepit.refined.auto._
+import io.constellationnetwork.BuildInfo
+import io.constellationnetwork.currency.l1.CurrencyL1App
+import io.constellationnetwork.dag.l1.domain.transaction.ContextualTransactionValidator.CustomValidationError
+import io.constellationnetwork.dag.l1.domain.transaction.{CustomContextualTransactionValidator, TransactionValidatorContext}
+import io.constellationnetwork.schema.cluster.ClusterId
+import io.constellationnetwork.schema.semver.{MetagraphVersion, TessellationVersion}
+import io.constellationnetwork.schema.transaction.Transaction
+import io.constellationnetwork.security.Hashed
 
 object Main
   extends CurrencyL1App(

--- a/examples/custom-transaction-validation/project/Dependencies.scala
+++ b/examples/custom-transaction-validation/project/Dependencies.scala
@@ -3,11 +3,11 @@ import sbt.*
 object Dependencies {
 
   object V {
-    val tessellation = "2.8.1"
+    val tessellation = "3.5.0-rc.0"
     val decline = "2.4.1"
   }
 
-  def tessellation(artifact: String): ModuleID = "org.constellation" %% s"tessellation-$artifact" % V.tessellation
+  def tessellation(artifact: String): ModuleID = "io.constellationnetwork" %% s"tessellation-$artifact" % V.tessellation
 
   def decline(artifact: String = ""): ModuleID =
     "com.monovore" %% {
@@ -15,9 +15,7 @@ object Dependencies {
     } % V.decline
 
   object Libraries {
-    val tessellationNodeShared = tessellation("node-shared")
-    val tessellationCurrencyL0 = tessellation("currency-l0")
-    val tessellationCurrencyL1 = tessellation("currency-l1")
+    val tessellationSdk = tessellation("sdk")
     val requests = "com.lihaoyi" %% "requests" % "0.8.0"
     val declineCore = decline()
     val declineEffect = decline("effect")

--- a/examples/custom-transaction-validation/project/plugins.sbt
+++ b/examples/custom-transaction-validation/project/plugins.sbt
@@ -6,6 +6,5 @@ addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.10.1")
 addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.5.3")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.2.0")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
-addSbtPlugin("com.codecommit" % "sbt-github-packages" % "0.5.3")
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.6.3")
 addDependencyTreePlugin


### PR DESCRIPTION
Updating the `custom-validation` metagraph example to use tessellation `3.5.0-rc0` and aligning with euclid `0.17.0`
