### PR TITLE
update `rewards-api` example

### DIFF
--- a/examples/reward-api/build.sbt
+++ b/examples/reward-api/build.sbt
@@ -29,13 +29,12 @@ lazy val currencyL1 = (project in file("modules/l1"))
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
     buildInfoPackage := "com.my.reward_api.l1",
     resolvers += Resolver.mavenLocal,
-    resolvers += Resolver.githubPackages("abankowski", "http-request-signer"),
     Defaults.itSettings,
     libraryDependencies ++= Seq(
       CompilerPlugin.kindProjector,
       CompilerPlugin.betterMonadicFor,
       CompilerPlugin.semanticDB,
-      Libraries.tessellationCurrencyL1
+      Libraries.tessellationSdk
     )
   )
 
@@ -49,7 +48,6 @@ lazy val currencyL0 = (project in file("modules/l0"))
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
     buildInfoPackage := "com.my.reward_api.l0",
     resolvers += Resolver.mavenLocal,
-    resolvers += Resolver.githubPackages("abankowski", "http-request-signer"),
     Defaults.itSettings,
     libraryDependencies ++= Seq(
       CompilerPlugin.kindProjector,
@@ -58,7 +56,7 @@ lazy val currencyL0 = (project in file("modules/l0"))
       Libraries.declineRefined,
       Libraries.declineCore,
       Libraries.declineEffect,
-      Libraries.tessellationCurrencyL0,
+      Libraries.tessellationSdk,
       Libraries.requests
     )
   )

--- a/examples/reward-api/modules/l0/src/main/scala/com/my/reward_api/l0/Main.scala
+++ b/examples/reward-api/modules/l0/src/main/scala/com/my/reward_api/l0/Main.scala
@@ -9,20 +9,20 @@ import eu.timepit.refined.numeric.Positive
 import eu.timepit.refined.refineV
 import eu.timepit.refined.types.numeric.PosLong
 import io.circe.parser.decode
-import org.tessellation.BuildInfo
-import org.tessellation.currency.dataApplication.DataCalculatedState
-import org.tessellation.currency.l0.CurrencyL0App
-import org.tessellation.currency.schema.currency.{CurrencyIncrementalSnapshot, CurrencySnapshotStateProof}
-import org.tessellation.node.shared.domain.rewards.Rewards
-import org.tessellation.node.shared.infrastructure.consensus.trigger.ConsensusTrigger
-import org.tessellation.node.shared.snapshot.currency.CurrencySnapshotEvent
-import org.tessellation.schema.address.Address
-import org.tessellation.schema.balance.Balance
-import org.tessellation.schema.cluster.ClusterId
-import org.tessellation.schema.semver.{MetagraphVersion, TessellationVersion}
-import org.tessellation.schema.transaction.{RewardTransaction, Transaction, TransactionAmount}
-import org.tessellation.security.SecurityProvider
-import org.tessellation.security.signature.Signed
+import io.constellationnetwork.BuildInfo
+import io.constellationnetwork.currency.dataApplication.DataCalculatedState
+import io.constellationnetwork.currency.l0.CurrencyL0App
+import io.constellationnetwork.currency.schema.currency.{CurrencyIncrementalSnapshot, CurrencySnapshotStateProof}
+import io.constellationnetwork.node.shared.domain.rewards.Rewards
+import io.constellationnetwork.node.shared.infrastructure.consensus.trigger.ConsensusTrigger
+import io.constellationnetwork.node.shared.snapshot.currency.CurrencySnapshotEvent
+import io.constellationnetwork.schema.address.Address
+import io.constellationnetwork.schema.balance.Balance
+import io.constellationnetwork.schema.cluster.ClusterId
+import io.constellationnetwork.schema.semver.{MetagraphVersion, TessellationVersion}
+import io.constellationnetwork.schema.transaction.{RewardTransaction, Transaction, TransactionAmount}
+import io.constellationnetwork.security.SecurityProvider
+import io.constellationnetwork.security.signature.Signed
 
 import java.util.UUID
 import scala.collection.immutable.{SortedMap, SortedSet}

--- a/examples/reward-api/modules/l1/src/main/scala/com/my/reward_api/l1/Main.scala
+++ b/examples/reward-api/modules/l1/src/main/scala/com/my/reward_api/l1/Main.scala
@@ -1,9 +1,9 @@
 package com.my.reward_api.l1
 
-import org.tessellation.BuildInfo
-import org.tessellation.currency.l1.CurrencyL1App
-import org.tessellation.schema.cluster.ClusterId
-import org.tessellation.schema.semver.{MetagraphVersion, TessellationVersion}
+import io.constellationnetwork.BuildInfo
+import io.constellationnetwork.currency.l1.CurrencyL1App
+import io.constellationnetwork.schema.cluster.ClusterId
+import io.constellationnetwork.schema.semver.{MetagraphVersion, TessellationVersion}
 
 import java.util.UUID
 

--- a/examples/reward-api/project/Dependencies.scala
+++ b/examples/reward-api/project/Dependencies.scala
@@ -3,11 +3,11 @@ import sbt.*
 object Dependencies {
 
   object V {
-    val tessellation = "2.8.1"
+    val tessellation = "3.5.0-rc.0"
     val decline = "2.4.1"
   }
 
-  def tessellation(artifact: String): ModuleID = "org.constellation" %% s"tessellation-$artifact" % V.tessellation
+  def tessellation(artifact: String): ModuleID = "io.constellationnetwork" %% s"tessellation-$artifact" % V.tessellation
 
   def decline(artifact: String = ""): ModuleID =
     "com.monovore" %% {
@@ -15,9 +15,7 @@ object Dependencies {
     } % V.decline
 
   object Libraries {
-    val tessellationNodeShared = tessellation("node-shared")
-    val tessellationCurrencyL0 = tessellation("currency-l0")
-    val tessellationCurrencyL1 = tessellation("currency-l1")
+    val tessellationSdk = tessellation("sdk")
     val requests = "com.lihaoyi" %% "requests" % "0.8.0"
     val declineCore = decline()
     val declineEffect = decline("effect")

--- a/examples/reward-api/project/plugins.sbt
+++ b/examples/reward-api/project/plugins.sbt
@@ -6,6 +6,5 @@ addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.10.1")
 addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.5.3")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.2.0")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
-addSbtPlugin("com.codecommit" % "sbt-github-packages" % "0.5.3")
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.6.3")
 addDependencyTreePlugin


### PR DESCRIPTION
Updating the `rewards-api` metagraph example to use tessellation `3.5.0-rc0` and aligning with euclid `0.17.0`

```
http://localhost:9200/snapshots/latest/combined
[
  {
    "value": {
      "ordinal": 25,
      "height": 0,
      "subHeight": 25,
      "lastSnapshotHash": "4d0ba1f90c4210203cf289b285387da824786b0c8fd035bbb62d6b6c02533fd5",
      "blocks": [],
      "rewards": [
        {
          "destination": "DAG4Zd2W2JxL1f1gsHQCoaKrRonPSSHLgcqD7osU",
          "amount": 333333333
        },
        {
          "destination": "DAG4o41NzhfX6DyYBTTXu6sJa6awm36abJpv89jB",
          "amount": 333333333
        },
        {
          "destination": "DAG8pkb7EhCkT3yU87B2yPBunSCPnEdmX2Wv24sZ",
          "amount": 333333333
        }
      ],
(...)
```