### PR TITLE
add blank metagraph template

### DIFF
--- a/examples/blank/build.sbt
+++ b/examples/blank/build.sbt
@@ -1,0 +1,100 @@
+import Dependencies._
+import sbt._
+
+ThisBuild / organization := "com.my.currency"
+ThisBuild / scalaVersion := "2.13.16"
+ThisBuild / evictionErrorLevel := Level.Warn
+
+ThisBuild / assemblyMergeStrategy := {
+  case "logback.xml"                                       => MergeStrategy.first
+  case x if x.contains("io.netty.versions.properties")     => MergeStrategy.discard
+  case PathList(xs @ _*) if xs.last == "module-info.class" => MergeStrategy.first
+  case x =>
+    val oldStrategy = (assembly / assemblyMergeStrategy).value
+    oldStrategy(x)
+}
+
+lazy val root = (project in file(".")).
+  settings(
+    name := "my-metagraph"
+  ).aggregate(sharedData, currencyL0, currencyL1, dataL1)
+
+lazy val sharedData = (project in file("modules/shared_data"))
+  .enablePlugins(AshScriptPlugin)
+  .enablePlugins(BuildInfoPlugin)
+  .enablePlugins(JavaAppPackaging)
+  .settings(
+    name := "my-metagraph-shared_data",
+    scalacOptions ++= List("-Ymacro-annotations", "-Yrangepos", "-Wconf:cat=unused:info", "-language:reflectiveCalls"),
+    buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
+    buildInfoPackage := "com.my.currency.shared_data",
+    resolvers += Resolver.mavenLocal,
+    Defaults.itSettings,
+    libraryDependencies ++= Seq(
+      CompilerPlugin.kindProjector,
+      CompilerPlugin.betterMonadicFor,
+      CompilerPlugin.semanticDB,
+      Libraries.tessellationSdk
+    )
+  )
+lazy val currencyL1 = (project in file("modules/l1"))
+  .enablePlugins(AshScriptPlugin)
+  .enablePlugins(BuildInfoPlugin)
+  .enablePlugins(JavaAppPackaging)
+  .settings(
+    name := "my-metagraph-currency-l1",
+    scalacOptions ++= List("-Ymacro-annotations", "-Yrangepos", "-Wconf:cat=unused:info", "-language:reflectiveCalls"),
+    buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
+    buildInfoPackage := "com.my.currency.l1",
+    resolvers += Resolver.mavenLocal,
+    Defaults.itSettings,
+    libraryDependencies ++= Seq(
+      CompilerPlugin.kindProjector,
+      CompilerPlugin.betterMonadicFor,
+      CompilerPlugin.semanticDB,
+      Libraries.tessellationSdk
+    )
+  )
+
+lazy val currencyL0 = (project in file("modules/l0"))
+  .enablePlugins(AshScriptPlugin)
+  .enablePlugins(BuildInfoPlugin)
+  .enablePlugins(JavaAppPackaging)
+  .dependsOn(sharedData)
+  .settings(
+    name := "my-metagraph-currency-l0",
+    scalacOptions ++= List("-Ymacro-annotations", "-Yrangepos", "-Wconf:cat=unused:info", "-language:reflectiveCalls"),
+    buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
+    buildInfoPackage := "com.my.currency.l0",
+    resolvers += Resolver.mavenLocal,
+    Defaults.itSettings,
+    libraryDependencies ++= Seq(
+      CompilerPlugin.kindProjector,
+      CompilerPlugin.betterMonadicFor,
+      CompilerPlugin.semanticDB,
+      Libraries.declineRefined,
+      Libraries.declineCore,
+      Libraries.declineEffect,
+      Libraries.tessellationSdk
+    )
+  )
+
+lazy val dataL1 = (project in file("modules/data_l1"))
+  .enablePlugins(AshScriptPlugin)
+  .enablePlugins(BuildInfoPlugin)
+  .enablePlugins(JavaAppPackaging)
+  .dependsOn(sharedData)
+  .settings(
+    name := "my-metagraph-data_l1",
+    scalacOptions ++= List("-Ymacro-annotations", "-Yrangepos", "-Wconf:cat=unused:info", "-language:reflectiveCalls"),
+    buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
+    buildInfoPackage := "com.my.currency.data_l1",
+    resolvers += Resolver.mavenLocal,
+    Defaults.itSettings,
+    libraryDependencies ++= Seq(
+      CompilerPlugin.kindProjector,
+      CompilerPlugin.betterMonadicFor,
+      CompilerPlugin.semanticDB,
+      Libraries.tessellationSdk
+    )
+  )

--- a/examples/blank/modules/data_l1/src/main/scala/com/my/currency/data_l1/Main.scala
+++ b/examples/blank/modules/data_l1/src/main/scala/com/my/currency/data_l1/Main.scala
@@ -1,0 +1,26 @@
+package com.my.currency.data_l1
+
+import java.util.UUID
+import io.constellationnetwork.BuildInfo
+import io.constellationnetwork.currency.l1.CurrencyL1App
+import io.constellationnetwork.schema.cluster.ClusterId
+import io.constellationnetwork.schema.semver.{MetagraphVersion, TessellationVersion}
+
+object Main
+    extends CurrencyL1App(
+      "my-metagraph-data_l1",
+      "my-metagraph data L1 data node",
+      ClusterId(UUID.fromString("517c3a05-9219-471b-a54c-21b7d72f4ae5")),
+      tessellationVersion = TessellationVersion.unsafeFrom(BuildInfo.version),
+      metagraphVersion = MetagraphVersion.unsafeFrom(BuildInfo.version)
+    ) {
+    /*
+    * To implement a data-l1 layer, you need to override the dataApplication function in CurrencyL1App:
+    * 
+    * override def dataApplication: Option[Resource[IO, BaseDataApplicationL1Service[IO]]]
+    *
+    * By default, this function returns None. If you do not provide an implementation, it will not function as a data layer,
+    * and will instead operate as a normal currency layer.
+    */
+
+}

--- a/examples/blank/modules/l0/src/main/scala/com/my/currency/l0/Main.scala
+++ b/examples/blank/modules/l0/src/main/scala/com/my/currency/l0/Main.scala
@@ -1,0 +1,21 @@
+package com.my.currency.l0
+
+import cats.effect.{IO, Resource}
+import io.constellationnetwork.BuildInfo
+import io.constellationnetwork.currency.dataApplication.{BaseDataApplicationL0Service}
+import io.constellationnetwork.currency.l0.CurrencyL0App
+import io.constellationnetwork.schema.cluster.ClusterId
+import io.constellationnetwork.security.SecurityProvider
+import io.constellationnetwork.schema.semver.{MetagraphVersion, TessellationVersion}
+
+import java.util.UUID
+
+  object Main
+    extends CurrencyL0App(
+      "my-metagraph-l0",
+      "my-metagraph L0 node",
+      ClusterId(UUID.fromString("517c3a05-9219-471b-a54c-21b7d72f4ae5")),
+      tessellationVersion = TessellationVersion.unsafeFrom(BuildInfo.version),
+      metagraphVersion = MetagraphVersion.unsafeFrom(BuildInfo.version)
+    ) {
+  }

--- a/examples/blank/modules/l1/src/main/scala/com/my/currency/l1/Main.scala
+++ b/examples/blank/modules/l1/src/main/scala/com/my/currency/l1/Main.scala
@@ -1,0 +1,16 @@
+package com.my.currency.l1
+
+import java.util.UUID
+import io.constellationnetwork.BuildInfo
+import io.constellationnetwork.currency.l1.CurrencyL1App
+import io.constellationnetwork.schema.cluster.ClusterId
+import io.constellationnetwork.schema.semver.{MetagraphVersion, TessellationVersion}
+
+object Main
+    extends CurrencyL1App(
+      "my-metagraph-l1",
+      "my-metagraph L1 node",
+      ClusterId(UUID.fromString("517c3a05-9219-471b-a54c-21b7d72f4ae5")),
+      tessellationVersion = TessellationVersion.unsafeFrom(BuildInfo.version),
+      metagraphVersion = MetagraphVersion.unsafeFrom(BuildInfo.version)
+    ) {}

--- a/examples/blank/modules/shared_data/src/main/scala/com/my/currency/shared_data/Main.scala
+++ b/examples/blank/modules/shared_data/src/main/scala/com/my/currency/shared_data/Main.scala
@@ -1,0 +1,3 @@
+object Main {
+
+}

--- a/examples/blank/project/Dependencies.scala
+++ b/examples/blank/project/Dependencies.scala
@@ -1,0 +1,40 @@
+import sbt._
+
+object Dependencies {
+
+  object V {
+    val tessellation = "3.5.18"
+    val decline = "2.4.1"
+  }
+  def tessellation(artifact: String): ModuleID = "io.constellationnetwork" %% s"tessellation-$artifact" % V.tessellation
+
+  def decline(artifact: String = ""): ModuleID =
+    "com.monovore" %% {
+      if (artifact.isEmpty) "decline" else s"decline-$artifact"
+    } % V.decline
+  object Libraries {
+    val tessellationSdk = tessellation("sdk")
+    val declineCore = decline()
+    val declineEffect = decline("effect")
+    val declineRefined = decline("refined")
+  }
+
+
+  // Scalafix rules
+  val organizeImports = "com.github.liancheng" %% "organize-imports" % "0.5.0"
+
+  object CompilerPlugin {
+
+    val betterMonadicFor = compilerPlugin(
+      "com.olegpy" %% "better-monadic-for" % "0.3.1"
+    )
+
+    val kindProjector = compilerPlugin(
+      ("org.typelevel" % "kind-projector" % "0.13.3").cross(CrossVersion.full)
+    )
+
+    val semanticDB = compilerPlugin(
+      ("org.scalameta" % "semanticdb-scalac" % "4.13.1.1").cross(CrossVersion.full)
+    )
+  }
+}

--- a/examples/blank/project/build.properties
+++ b/examples/blank/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.9.8

--- a/examples/blank/project/plugins.sbt
+++ b/examples/blank/project/plugins.sbt
@@ -1,0 +1,10 @@
+addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.4.1")
+addSbtPlugin("io.spray" % "sbt-revolver" % "0.9.1")
+addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.11")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.10.1")
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.5.3")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.2.0")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.6.3")
+addDependencyTreePlugin


### PR DESCRIPTION
adding a blank metagraph as template, to be used with new hydra (TS version), `hydra install-template --name blank`. The contents have been generated with the current version of https://github.com/Constellation-Labs/currency.g8 to match the old custom project structure.